### PR TITLE
README.md의 잘못된 링크 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Velog is a blog platform for developers. It provides markdown editor with syntax
 
 Website link: https://velog.io/
 
-Frontend project of service is at another Repo - [velog-client](https://github.com/velopert/velog-server)
+Frontend project of service is at another Repo - [velog-client](https://github.com/velopert/velog-client)
 
 ## Project Stack
 - Node.js


### PR DESCRIPTION
"velog-client"의 링크를 velog-server에서 velog-client로 변경했습니다.