### PR TITLE
Bump elasticsearch docker base image to support arm64

### DIFF
--- a/docker/search/Dockerfile
+++ b/docker/search/Dockerfile
@@ -1,3 +1,3 @@
 
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.3.2
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.13.0
 RUN elasticsearch-plugin install analysis-nori


### PR DESCRIPTION
Following this [doc](https://github.com/velopert/velog-server/wiki/Running-on-your-machine#elasticsearch), found an issue that the current elasticsearch docker base image doesn't support arm64 architecture.

![image](https://user-images.githubusercontent.com/538584/120323846-e7c8d300-c320-11eb-8404-d5bc7c957232.png)

After bumping the version of elasticsearch from 7.3.2 to 7.13.0, the latest one, it started to work like a charm on my apple m1 local machine. Looks like elasticsearch has supported arm64 from v7.8.0.
![image](https://user-images.githubusercontent.com/538584/120324148-42fac580-c321-11eb-8c72-15e60a4b91aa.png)

Hope this help other ones contribute to velog little bit easier, thanks.